### PR TITLE
Made hello runnable without gunicorn in debug mode

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -83,3 +83,6 @@ def operation():
 @app.route('/centroids', methods=['POST'])
 def api_centroids():
   return get_centroids(request.data)
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
You can run it like this:

```
$ python hello.py
```

[Flask’s debug mode](http://flask.pocoo.org/docs/quickstart/#debug-mode) outputs better error details than gunicorn, during dev + debug time. Also, auto-reloads the server when source files change!
